### PR TITLE
Added the return data for brought forward losses used to the calculator.

### DIFF
--- a/app/controllers/resident/properties/CalculatorController.scala
+++ b/app/controllers/resident/properties/CalculatorController.scala
@@ -80,29 +80,19 @@ trait CalculatorController extends BaseController {
     val aeaRemaining = calculationService.annualExemptAmountLeft(annualExemptAmount, aeaUsed)
     val deductions = prrUsed + reliefsUsed + round("up", allowableLosses.getOrElse(0.0)) + aeaUsed + round("up", broughtForwardLosses.getOrElse(0.0))
     val allowableLossesRemaining = CalculationService.determineLossLeft(gain - (reliefsUsed + prrUsed), round("up", allowableLosses.getOrElse(0)))
-    val broughtForwardLossesRemaining = CalculationService.determineLossLeft(gain - (reliefsUsed + prrUsed + round("up", allowableLosses.getOrElse(0.0)) + aeaUsed), broughtForwardLosses.getOrElse(0))
-    val result = ChargeableGainResultModel(gain, chargeableGain, aeaUsed, aeaRemaining, deductions, allowableLossesRemaining, broughtForwardLossesRemaining, Some(reliefsUsed), Some(prrUsed))
+    val broughtForwardLossesRemaining = CalculationService.determineLossLeft(gain - (reliefsUsed + prrUsed + round("up", allowableLosses.getOrElse(0.0)) +
+      aeaUsed), broughtForwardLosses.getOrElse(0))
+    val broughtForwardLossesUsed = CalculationService.determineBFLossLeft(round("up", broughtForwardLosses.getOrElse(0)), broughtForwardLossesRemaining)
+    val result = ChargeableGainResultModel(gain, chargeableGain, aeaUsed, aeaRemaining, deductions, allowableLossesRemaining, broughtForwardLossesRemaining,
+      Some(reliefsUsed), Some(prrUsed), Some(broughtForwardLossesUsed))
 
     Future.successful(Ok(Json.toJson(result)))
   }
 
-  def calculateTaxOwed
-  (
-    disposalValue: Double,
-    disposalCosts: Double,
-    acquisitionValue: Double,
-    acquisitionCosts: Double,
-    improvements: Double,
-    prrType: String,
-    prrValue: Option[Double],
-    reliefs: Option[Double],
-    allowableLosses: Option[Double],
-    broughtForwardLosses: Option[Double],
-    annualExemptAmount: Double,
-    previousTaxableGain: Option[Double],
-    previousIncome: Double,
-    personalAllowance: Double,
-    disposalDate: String = "2015-10-10"
+  def calculateTaxOwed(disposalValue: Double, disposalCosts: Double, acquisitionValue: Double, acquisitionCosts: Double,
+    improvements: Double, prrType: String, prrValue: Option[Double], reliefs: Option[Double], allowableLosses: Option[Double],
+    broughtForwardLosses: Option[Double], annualExemptAmount: Double, previousTaxableGain: Option[Double],
+    previousIncome: Double, personalAllowance: Double, disposalDate: String = "2015-10-10"
   ): Action[AnyContent] = Action.async { implicit request =>
 
     val taxYear = getTaxYear(DateTime.parse(disposalDate))
@@ -115,26 +105,14 @@ trait CalculatorController extends BaseController {
       gain, reliefsUsed + prrUsed, allowableLosses.getOrElse(0.0), annualExemptAmount, broughtForwardLosses.getOrElse(0.0)
     )
     val aeaUsed: Double = calculationService.annualExemptAmountUsed(
-      annualExemptAmount,
-      gain,
+      annualExemptAmount, gain,
       calculationService.calculateChargeableGain(gain, reliefsUsed + prrUsed, allowableLosses.getOrElse(0.0), annualExemptAmount, 0.0),
-      reliefsUsed + prrUsed,
-      allowableLosses.getOrElse(0.0)
+      reliefsUsed + prrUsed, allowableLosses.getOrElse(0.0)
     )
     val deductions = prrUsed + reliefsUsed + allowableLosses.getOrElse(0.0) + aeaUsed + broughtForwardLosses.getOrElse(0.0)
-    val calculationResult: CalculationResultModel  = calculationService.calculationResult (
-      "individual",
-      gain,
-      chargeableGain,
-      negativeToZero(chargeableGain),
+    val calculationResult: CalculationResultModel  = calculationService.calculationResult ("individual", gain, chargeableGain, negativeToZero(chargeableGain),
       calculationService.brRemaining(previousIncome, personalAllowance, previousTaxableGain.getOrElse(0.0), Date.getTaxYear(DateTime.parse(disposalDate))),
-      0.0,
-      "No",
-      aeaUsed,
-      0.0,
-      calcTaxYear,
-      true
-    )
+      0.0, "No", aeaUsed, 0.0, calcTaxYear, true)
     val result: TaxOwedResultModel = TaxOwedResultModel(
       gain,
       chargeableGain,
@@ -146,7 +124,10 @@ trait CalculatorController extends BaseController {
       calculationResult.upperTaxGain,
       calculationResult.upperTaxRate,
       Some(reliefsUsed),
-      Some(prrUsed)
+      Some(prrUsed),
+      //Logic here is that there has been a total gain made.  Therefore any brought forward losses gained have been used entirely.
+      //As such it returns either a 0 if no losses were supplied or the value of the losses supplied.
+      Some(broughtForwardLosses.getOrElse(0))
     )
     Future.successful(Ok(Json.toJson(result)))
   }

--- a/app/models/resident/ChargeableGainResultModel.scala
+++ b/app/models/resident/ChargeableGainResultModel.scala
@@ -28,7 +28,8 @@ case class ChargeableGainResultModel
   allowableLossesRemaining: Double,
   broughtForwardLossesRemaining: Double,
   reliefsUsed: Option[Double],
-  prrUsed: Option[Double]
+  prrUsed: Option[Double],
+  broughtForwardLossesUsed: Option[Double]
 )
 
 object ChargeableGainResultModel {

--- a/app/models/resident/TaxOwedResultModel.scala
+++ b/app/models/resident/TaxOwedResultModel.scala
@@ -30,7 +30,8 @@ case class TaxOwedResultModel
   secondBand: Option[Double],
   secondRate: Option[Int],
   reliefsUsed: Option[Double],
-  prrUsed: Option[Double]
+  prrUsed: Option[Double],
+  broughtForwardLossesUsed: Option[Double]
 )
 
 object TaxOwedResultModel {

--- a/app/services/CalculationService.scala
+++ b/app/services/CalculationService.scala
@@ -313,4 +313,8 @@ trait CalculationService {
       case None => 0
     }
   }
+
+  def determineBFLossLeft(lossesBeforeCalculation: Double, lossesUsed: Double): Double = {
+    round("up", lossesBeforeCalculation - lossesUsed)
+  }
 }

--- a/test/controllers/resident/properties/CalculatorControllerSpec.scala
+++ b/test/controllers/resident/properties/CalculatorControllerSpec.scala
@@ -113,6 +113,10 @@ class CalculatorControllerSpec extends UnitSpec with WithFakeApplication {
         "has the prr used as £0" in {
           (json \ "prrUsed").as[Double] shouldBe 0
         }
+
+        "has the broughtForwardLossesUsed as £10900" in {
+          (json \ "broughtForwardLossesUsed").as[Double] shouldBe 10900
+        }
       }
     }
 
@@ -179,6 +183,10 @@ class CalculatorControllerSpec extends UnitSpec with WithFakeApplication {
 
         "has the prr used as £0" in {
           (json \ "prrUsed").as[Double] shouldBe 0
+        }
+
+        "has the broughtForwardLossesUsed as £11900" in {
+          (json \ "broughtForwardLossesUsed").as[Double] shouldBe 11900
         }
       }
     }
@@ -247,6 +255,10 @@ class CalculatorControllerSpec extends UnitSpec with WithFakeApplication {
         "has the prr used as £200" in {
           (json \ "prrUsed").as[Double] shouldBe 200
         }
+
+        "has the broughtForwardLossesUsed as £0" in {
+          (json \ "broughtForwardLossesUsed").as[Double] shouldBe 0
+        }
       }
     }
 
@@ -313,6 +325,10 @@ class CalculatorControllerSpec extends UnitSpec with WithFakeApplication {
 
         "has the prr used as £28000" in {
           (json \ "prrUsed").as[Double] shouldBe 28000
+        }
+
+        "has the broughtForwardLossesUsed as £0" in {
+          (json \ "broughtForwardLossesUsed").as[Double] shouldBe 0
         }
       }
     }
@@ -395,6 +411,10 @@ class CalculatorControllerSpec extends UnitSpec with WithFakeApplication {
         "has the prr used as £0" in {
           (json \ "prrUsed").as[Double] shouldBe 0
         }
+
+        "has the broughtForwardLossesUsed as £0" in {
+          (json \ "broughtForwardLossesUsed").as[Double] shouldBe 0
+        }
       }
     }
 
@@ -471,6 +491,10 @@ class CalculatorControllerSpec extends UnitSpec with WithFakeApplication {
 
         "has the prr used as £1000" in {
           (json \ "prrUsed").as[Double] shouldBe 1000
+        }
+
+        "has the broughtForwardLossesUsed as £10000" in {
+          (json \ "broughtForwardLossesUsed").as[Double] shouldBe 10000
         }
       }
     }

--- a/test/controllers/resident/shares/CalculatorControllerSpec.scala
+++ b/test/controllers/resident/shares/CalculatorControllerSpec.scala
@@ -101,6 +101,10 @@ class CalculatorControllerSpec extends UnitSpec with WithFakeApplication {
         "has the broughtForwardLossesRemaining as £3100" in {
           (json \ "broughtForwardLossesRemaining").as[Double] shouldBe 3100
         }
+
+        "has the broughtForwardLossesUsed as £16900" in {
+          (json \ "broughtForwardLossesUsed").as[Double] shouldBe 16900
+        }
       }
     }
 
@@ -155,6 +159,10 @@ class CalculatorControllerSpec extends UnitSpec with WithFakeApplication {
 
         "has the broughtForwardLossesRemaining as £3100" in {
           (json \ "broughtForwardLossesRemaining").as[Double] shouldBe 3100
+        }
+
+        "has the broughtForwardLossesUsed as £16900" in {
+          (json \ "broughtForwardLossesUsed").as[Double] shouldBe 16900
         }
       }
     }
@@ -226,6 +234,10 @@ class CalculatorControllerSpec extends UnitSpec with WithFakeApplication {
         "has no second tax band" in {
           (json \ "secondBand").as[Option[Double]] shouldBe None
         }
+
+        "has the broughtForwardLossesUsed as £0" in {
+          (json \ "broughtForwardLossesUsed").as[Double] shouldBe 0
+        }
       }
     }
 
@@ -292,6 +304,10 @@ class CalculatorControllerSpec extends UnitSpec with WithFakeApplication {
         "has a second tax band of 67115" in {
           (json \ "secondBand").as[Option[Double]] shouldBe Some(67115)
         }
+
+        "has the broughtForwardLossesUsed as £10000" in {
+          (json \ "broughtForwardLossesUsed").as[Double] shouldBe 10000
+        }
       }
     }
 
@@ -357,6 +373,10 @@ class CalculatorControllerSpec extends UnitSpec with WithFakeApplication {
 
         "has a second tax band of 66900" in {
           (json \ "secondBand").as[Option[Double]] shouldBe Some(66900)
+        }
+
+        "has the broughtForwardLossesUsed as £10000" in {
+          (json \ "broughtForwardLossesUsed").as[Double] shouldBe 10000
         }
       }
     }


### PR DESCRIPTION
Merge onto the new master-MVP-1 branch.

There are also some comments left in to explain the exact logic I'm using.  (<a href="https://github.com/hmrc/capital-gains-calculator/blob/0066189577bd7b0b89994e54c42ff5580a687802/app/controllers/resident/properties/CalculatorController.scala#L128-L129"> Here </a>) These are in both the properties and the shares.