### PR TITLE
DL-6763 - Added leak exemption

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -1,2 +1,5 @@
 digital-service: Capital Gains Tax Calculators
 repoVisibility: public_0C3F0CE3E6E6448FAD341E7BFA50FCD333E06A20CFF05FCACE61154DDBBADF71
+leakDetectionExemptions:
+  - ruleId: 'aws_secret_access_key'
+    filePath: '/app/common/binders/NonResidentTimeApportionmentCalculationRequestBinder.scala'


### PR DESCRIPTION
# DL-6763 - Added leak exemption

https://github.com/hmrc/init-service-private/blob/master/repository.yaml uses `filePath` but the confluence for adding exemptions uses `filePaths` in the examples. Went with `filePath`.

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
