### PR TITLE
DLS-10172 | Make latest tax year go live date configurable

### DIFF
--- a/app/config/taxRatesAndBands.scala
+++ b/app/config/taxRatesAndBands.scala
@@ -16,6 +16,8 @@
 
 package config
 
+import com.typesafe.config.ConfigFactory
+
 import java.time.LocalDate
 
 trait TaxRatesAndBands {
@@ -41,11 +43,13 @@ trait TaxRatesAndBands {
 
 object TaxRatesAndBands {
 
+  val latestTaxYearGoLiveDate: LocalDate = LocalDate.parse(ConfigFactory.load().getString("latest-tax-year-go-live-date"))
+
   val allRates: List[TaxRatesAndBands] = TaxRatesAndBands20152016 :: TaxRatesAndBands20162017 :: TaxRatesAndBands20172018 ::
     TaxRatesAndBands20182019 :: TaxRatesAndBands20192020 :: TaxRatesAndBands20202021 :: TaxRatesAndBands20212022 ::
     TaxRatesAndBands20222023 :: TaxRatesAndBands20232024 :: TaxRatesAndBands20242025 :: Nil
 
-  val liveTaxRates: List[TaxRatesAndBands] = if (LocalDate.now.isBefore(getLatestTaxYearLiveDate)) allRates.dropRight(1) else allRates
+  val liveTaxRates: List[TaxRatesAndBands] = if (LocalDate.now.isBefore(latestTaxYearGoLiveDate)) allRates.dropRight(1) else allRates
 
   def getRates(year: Int): TaxRatesAndBands = liveTaxRates.filter(_.taxYear == year) match {
     case params if params.nonEmpty => params.head
@@ -63,7 +67,6 @@ object TaxRatesAndBands {
 
   def getEarliestTaxYear: TaxRatesAndBands = liveTaxRates.minBy(_.taxYear)
 
-  def getLatestTaxYearLiveDate: LocalDate = LocalDate.parse(s"${allRates.last.taxYear}-04-06")
 }
 
 object TaxRatesAndBands20242025 extends TaxRatesAndBands {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -106,3 +106,5 @@ microservice {
         }
     }
 }
+
+latest-tax-year-go-live-date="2024-03-06"


### PR DESCRIPTION
DLS-10172: Make latest tax year configurable, for ease of testing

**New feature**

When there is a new tax year config change introduced, we would like to verify the user journey before hand rather than waiting for rollover to new tax year. This PR is to make that configurable so that it would be easier to verify changes in QA/Staging accordingly.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
