### PR TITLE
DLS-11724 | Temp change to manually include new tax year

### DIFF
--- a/app/config/taxRatesAndBands.scala
+++ b/app/config/taxRatesAndBands.scala
@@ -50,7 +50,8 @@ object TaxRatesAndBands {
   val allRates: List[TaxRatesAndBands] =
     TaxRatesAndBands20152016 :: TaxRatesAndBands20162017 :: TaxRatesAndBands20172018 ::
       TaxRatesAndBands20182019 :: TaxRatesAndBands20192020 :: TaxRatesAndBands20202021 :: TaxRatesAndBands20212022 ::
-      TaxRatesAndBands20222023 :: TaxRatesAndBands20232024 :: TaxRatesAndBands20242025 :: TaxRatesAndBands20242025MidYearChange :: Nil
+      TaxRatesAndBands20222023 :: TaxRatesAndBands20232024 :: TaxRatesAndBands20242025 :: TaxRatesAndBands20242025MidYearChange ::
+      TaxRatesAndBands20252026 :: Nil
 
   val liveTaxRates: List[TaxRatesAndBands] =
     if (LocalDate.now.isBefore(latestTaxYearGoLiveDate)) allRates.dropRight(1) else allRates
@@ -93,6 +94,24 @@ object TaxRatesAndBands {
 
   def getEarliestTaxYear: TaxRatesAndBands = liveTaxRates.minBy(_.taxYear)
 
+}
+
+object TaxRatesAndBands20252026 extends TaxRatesAndBands {
+  override val taxYear                            = 2026
+  override val maxAnnualExemptAmount              = 3000
+  override val notVulnerableMaxAnnualExemptAmount = 3000
+  override val basicRatePercentage                = 18
+  override val higherRatePercentage               = 24
+  override val shareBasicRatePercentage           = 18
+  override val shareHigherRatePercentage          = 24
+  override val maxPersonalAllowance               = 12570
+  override val basicRate                          = basicRatePercentage / 100.toDouble
+  override val higherRate                         = higherRatePercentage / 100.toDouble
+  override val shareBasicRate                     = shareBasicRatePercentage / 100.toDouble
+  override val shareHigherRate                    = shareHigherRatePercentage / 100.toDouble
+  override val basicRateBand                      = 37700
+  override val blindPersonsAllowance              = 2870
+  override val maxLettingsRelief                  = 40000.0
 }
 
 object TaxRatesAndBands20242025MidYearChange extends TaxRatesAndBands {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -107,6 +107,6 @@ microservice {
     }
 }
 
-latest-tax-year-go-live-date="2024-04-06"
+latest-tax-year-go-live-date="2025-04-06"
 
 mid-year-tax-change-effective-date="2024-10-31"

--- a/test/controllers/TaxRatesAndBandsControllerSpec.scala
+++ b/test/controllers/TaxRatesAndBandsControllerSpec.scala
@@ -328,8 +328,8 @@ class TaxRatesAndBandsControllerSpec extends PlaySpec with GuiceOneAppPerSuite w
         (json \ "isValidYear").as[Boolean] mustBe false
       }
 
-      "return a supplied TaxYearModel with calculationTaxYear as 2024/25" in {
-        (json \ "calculationTaxYear").as[String] mustBe "2024/25"
+      "return a supplied TaxYearModel with calculationTaxYear as 2025/26" in {
+        (json \ "calculationTaxYear").as[String] mustBe "2025/26"
       }
 
     }


### PR DESCRIPTION
- Another release will follow that will undo this but extend the tax year list to be dynamic for new tax year. Rush for temp change is to address live issues that is stopping users from returns.
- bot comments will also be addressed in next PR