### PR TITLE
DLS-13195 | Resolve to latest tax config for missing tax years

### DIFF
--- a/app/common/validation/CommonValidation.scala
+++ b/app/common/validation/CommonValidation.scala
@@ -59,8 +59,7 @@ object CommonValidation {
     else Left(s"$key has too many decimal places.")
 
   def validateResidentPersonalAllowance(input: Double, disposalDate: LocalDate): Either[String, Double] = {
-    val closestTaxYear       = TaxRatesAndBands.getClosestTaxYear(Date.getTaxYear(disposalDate))
-    val taxBands             = TaxRatesAndBands.getRates(closestTaxYear, Some(disposalDate))
+    val taxBands             = TaxRatesAndBands.getRates(Date.getTaxYear(disposalDate), Some(disposalDate))
     val maxPersonalAllowance =
       taxBands.maxPersonalAllowance + taxBands.blindPersonsAllowance + taxBands.marriageAllowance
 

--- a/app/config/taxRatesAndBands.scala
+++ b/app/config/taxRatesAndBands.scala
@@ -20,26 +20,27 @@ import com.typesafe.config.ConfigFactory
 
 import java.time.LocalDate
 
-trait TaxRatesAndBands {
-  val taxYear: Int
-  val maxAnnualExemptAmount: Int
-  val notVulnerableMaxAnnualExemptAmount: Int
-  val basicRatePercentage: Int
-  val higherRatePercentage: Int
-  val shareBasicRatePercentage: Int
-  val shareHigherRatePercentage: Int
-  val maxPersonalAllowance: Int
-  val basicRate: Double
-  val higherRate: Double
-  val shareBasicRate: Double
-  val shareHigherRate: Double
-  val basicRateBand: Int
-  val blindPersonsAllowance: Int
-  val marriageAllowance                = 1260
-  val maxLettingsRelief: Double
-  val startOfTax                       = "2015-04-06"
-  val startOfTaxLocalDate: LocalDate   = LocalDate.parse(startOfTax)
-  val effectiveDate: Option[LocalDate] = None
+case class TaxRatesAndBands(
+  taxYear: Int,
+  maxAnnualExemptAmount: Int,
+  notVulnerableMaxAnnualExemptAmount: Int,
+  basicRatePercentage: Int,
+  higherRatePercentage: Int,
+  shareBasicRatePercentage: Int,
+  shareHigherRatePercentage: Int,
+  maxPersonalAllowance: Int,
+  basicRateBand: Int,
+  blindPersonsAllowance: Int,
+  maxLettingsRelief: Double,
+  marriageAllowance: Int = 1260,
+  startOfTax: String = "2015-04-06",
+  effectiveDate: Option[LocalDate] = None
+) {
+  val basicRate: Double              = basicRatePercentage / 100.toDouble
+  val higherRate: Double             = higherRatePercentage / 100.toDouble
+  val shareBasicRate: Double         = shareBasicRatePercentage / 100.toDouble
+  val shareHigherRate: Double        = shareHigherRatePercentage / 100.toDouble
+  val startOfTaxLocalDate: LocalDate = LocalDate.parse(startOfTax)
 }
 
 object TaxRatesAndBands {
@@ -64,12 +65,23 @@ object TaxRatesAndBands {
     disposalDate: Option[LocalDate] = None,
     isMidYearChangeApplicable: Boolean = false
   ): TaxRatesAndBands =
-    liveTaxRates.filter(_.taxYear == year) match {
+    getRates(year, liveTaxRates, disposalDate, isMidYearChangeApplicable)
+
+  private[config] def getRates(
+    year: Int,
+    rates: List[TaxRatesAndBands],
+    disposalDate: Option[LocalDate],
+    isMidYearChangeApplicable: Boolean
+  ): TaxRatesAndBands =
+    rates.filter(_.taxYear == year) match {
       case params if params.size > 1 && isMidYearChangeApplicable =>
         getTaxRatesAndBandsForMidYearChange(params, disposalDate)
       case params if params.nonEmpty                              => params.head
-      case _                                                      => liveTaxRates.maxBy(_.taxYear)
+      case _                                                      => latestRatesUpTo(rates, year).copy(taxYear = year, effectiveDate = None)
     }
+
+  private[config] def latestRatesUpTo(rates: List[TaxRatesAndBands], year: Int): TaxRatesAndBands =
+    rates.filter(_.taxYear <= year).lastOption.getOrElse(rates.last)
 
   private def getTaxRatesAndBandsForMidYearChange(
     liveTaxRates: List[TaxRatesAndBands],
@@ -99,221 +111,183 @@ object TaxRatesAndBands {
 
 }
 
-object TaxRatesAndBands20252026 extends TaxRatesAndBands {
-  override val taxYear                            = 2026
-  override val maxAnnualExemptAmount              = 3000
-  override val notVulnerableMaxAnnualExemptAmount = 1500
-  override val basicRatePercentage                = 18
-  override val higherRatePercentage               = 24
-  override val shareBasicRatePercentage           = 18
-  override val shareHigherRatePercentage          = 24
-  override val maxPersonalAllowance               = 12570
-  override val basicRate                          = basicRatePercentage / 100.toDouble
-  override val higherRate                         = higherRatePercentage / 100.toDouble
-  override val shareBasicRate                     = shareBasicRatePercentage / 100.toDouble
-  override val shareHigherRate                    = shareHigherRatePercentage / 100.toDouble
-  override val basicRateBand                      = 37700
-  override val blindPersonsAllowance              = 2870
-  override val maxLettingsRelief                  = 40000.0
-}
-
-object TaxRatesAndBands20242025MidYearChange extends TaxRatesAndBands {
-  override val taxYear                            = 2025
-  override val maxAnnualExemptAmount              = 3000
-  override val notVulnerableMaxAnnualExemptAmount = 1500
-  override val basicRatePercentage                = 18
-  override val higherRatePercentage               = 24
-  override val shareBasicRatePercentage           = 18
-  override val shareHigherRatePercentage          = 24
-  override val maxPersonalAllowance               = 12570
-  override val basicRate                          = basicRatePercentage / 100.toDouble
-  override val higherRate                         = higherRatePercentage / 100.toDouble
-  override val shareBasicRate                     = shareBasicRatePercentage / 100.toDouble
-  override val shareHigherRate                    = shareHigherRatePercentage / 100.toDouble
-  override val basicRateBand                      = 37700
-  override val blindPersonsAllowance              = 2870
-  override val maxLettingsRelief                  = 40000.0
-  override val effectiveDate                      = Some(
-    LocalDate.parse(ConfigFactory.load().getString("mid-year-tax-change-effective-date"))
+def TaxRatesAndBands20252026: TaxRatesAndBands =
+  TaxRatesAndBands(
+    taxYear = 2026,
+    maxAnnualExemptAmount = 3000,
+    notVulnerableMaxAnnualExemptAmount = 1500,
+    basicRatePercentage = 18,
+    higherRatePercentage = 24,
+    shareBasicRatePercentage = 18,
+    shareHigherRatePercentage = 24,
+    maxPersonalAllowance = 12570,
+    basicRateBand = 37700,
+    blindPersonsAllowance = 2870,
+    maxLettingsRelief = 40000.0
   )
-}
 
-object TaxRatesAndBands20242025 extends TaxRatesAndBands {
-  override val taxYear                            = 2025
-  override val maxAnnualExemptAmount              = 3000
-  override val notVulnerableMaxAnnualExemptAmount = 3000
-  override val basicRatePercentage                = 18
-  override val higherRatePercentage               = 24
-  override val shareBasicRatePercentage           = 10
-  override val shareHigherRatePercentage          = 20
-  override val maxPersonalAllowance               = 12570
-  override val basicRate                          = basicRatePercentage / 100.toDouble
-  override val higherRate                         = higherRatePercentage / 100.toDouble
-  override val shareBasicRate                     = shareBasicRatePercentage / 100.toDouble
-  override val shareHigherRate                    = shareHigherRatePercentage / 100.toDouble
-  override val basicRateBand                      = 37700
-  override val blindPersonsAllowance              = 2870
-  override val maxLettingsRelief                  = 40000.0
-}
+def TaxRatesAndBands20242025MidYearChange: TaxRatesAndBands =
+  TaxRatesAndBands(
+    taxYear = 2025,
+    maxAnnualExemptAmount = 3000,
+    notVulnerableMaxAnnualExemptAmount = 1500,
+    basicRatePercentage = 18,
+    higherRatePercentage = 24,
+    shareBasicRatePercentage = 18,
+    shareHigherRatePercentage = 24,
+    maxPersonalAllowance = 12570,
+    basicRateBand = 37700,
+    blindPersonsAllowance = 2870,
+    maxLettingsRelief = 40000.0,
+    effectiveDate = Some(LocalDate.parse(ConfigFactory.load().getString("mid-year-tax-change-effective-date")))
+  )
 
-object TaxRatesAndBands20232024 extends TaxRatesAndBands {
-  override val taxYear                            = 2024
-  override val maxAnnualExemptAmount              = 6000
-  override val notVulnerableMaxAnnualExemptAmount = 3000
-  override val basicRatePercentage                = 18
-  override val higherRatePercentage               = 28
-  override val shareBasicRatePercentage           = 10
-  override val shareHigherRatePercentage          = 20
-  override val maxPersonalAllowance               = 12570
-  override val basicRate                          = basicRatePercentage / 100.toDouble
-  override val higherRate                         = higherRatePercentage / 100.toDouble
-  override val shareBasicRate                     = shareBasicRatePercentage / 100.toDouble
-  override val shareHigherRate                    = shareHigherRatePercentage / 100.toDouble
-  override val basicRateBand                      = 37700
-  override val blindPersonsAllowance              = 2870
-  override val maxLettingsRelief                  = 40000.0
-}
+def TaxRatesAndBands20242025: TaxRatesAndBands =
+  TaxRatesAndBands(
+    taxYear = 2025,
+    maxAnnualExemptAmount = 3000,
+    notVulnerableMaxAnnualExemptAmount = 3000,
+    basicRatePercentage = 18,
+    higherRatePercentage = 24,
+    shareBasicRatePercentage = 10,
+    shareHigherRatePercentage = 20,
+    maxPersonalAllowance = 12570,
+    basicRateBand = 37700,
+    blindPersonsAllowance = 2870,
+    maxLettingsRelief = 40000.0
+  )
 
-object TaxRatesAndBands20222023 extends TaxRatesAndBands {
-  override val taxYear                            = 2023
-  override val maxAnnualExemptAmount              = 12300
-  override val notVulnerableMaxAnnualExemptAmount = 6150
-  override val basicRatePercentage                = 18
-  override val higherRatePercentage               = 28
-  override val shareBasicRatePercentage           = 10
-  override val shareHigherRatePercentage          = 20
-  override val maxPersonalAllowance               = 12570
-  override val basicRate                          = basicRatePercentage / 100.toDouble
-  override val higherRate                         = higherRatePercentage / 100.toDouble
-  override val shareBasicRate                     = shareBasicRatePercentage / 100.toDouble
-  override val shareHigherRate                    = shareHigherRatePercentage / 100.toDouble
-  override val basicRateBand                      = 37700
-  override val blindPersonsAllowance              = 2600
-  override val maxLettingsRelief                  = 40000.0
-}
+def TaxRatesAndBands20232024: TaxRatesAndBands =
+  TaxRatesAndBands(
+    taxYear = 2024,
+    maxAnnualExemptAmount = 6000,
+    notVulnerableMaxAnnualExemptAmount = 3000,
+    basicRatePercentage = 18,
+    higherRatePercentage = 28,
+    shareBasicRatePercentage = 10,
+    shareHigherRatePercentage = 20,
+    maxPersonalAllowance = 12570,
+    basicRateBand = 37700,
+    blindPersonsAllowance = 2870,
+    maxLettingsRelief = 40000.0
+  )
 
-object TaxRatesAndBands20212022 extends TaxRatesAndBands {
-  override val taxYear                            = 2022
-  override val maxAnnualExemptAmount              = 12300
-  override val notVulnerableMaxAnnualExemptAmount = 6150
-  override val basicRatePercentage                = 18
-  override val higherRatePercentage               = 28
-  override val shareBasicRatePercentage           = 10
-  override val shareHigherRatePercentage          = 20
-  override val maxPersonalAllowance               = 12570
-  override val basicRate                          = basicRatePercentage / 100.toDouble
-  override val higherRate                         = higherRatePercentage / 100.toDouble
-  override val shareBasicRate                     = shareBasicRatePercentage / 100.toDouble
-  override val shareHigherRate                    = shareHigherRatePercentage / 100.toDouble
-  override val basicRateBand                      = 37700
-  override val blindPersonsAllowance              = 2520
-  override val maxLettingsRelief                  = 40000.0
-}
+def TaxRatesAndBands20222023: TaxRatesAndBands =
+  TaxRatesAndBands(
+    taxYear = 2023,
+    maxAnnualExemptAmount = 12300,
+    notVulnerableMaxAnnualExemptAmount = 6150,
+    basicRatePercentage = 18,
+    higherRatePercentage = 28,
+    shareBasicRatePercentage = 10,
+    shareHigherRatePercentage = 20,
+    maxPersonalAllowance = 12570,
+    basicRateBand = 37700,
+    blindPersonsAllowance = 2600,
+    maxLettingsRelief = 40000.0
+  )
 
-object TaxRatesAndBands20202021 extends TaxRatesAndBands {
-  override val taxYear                            = 2021
-  override val maxAnnualExemptAmount              = 12300
-  override val notVulnerableMaxAnnualExemptAmount = 6000
-  override val basicRatePercentage                = 18
-  override val higherRatePercentage               = 28
-  override val shareBasicRatePercentage           = 10
-  override val shareHigherRatePercentage          = 20
-  override val maxPersonalAllowance               = 12500
-  override val basicRate                          = basicRatePercentage / 100.toDouble
-  override val higherRate                         = higherRatePercentage / 100.toDouble
-  override val shareBasicRate                     = shareBasicRatePercentage / 100.toDouble
-  override val shareHigherRate                    = shareHigherRatePercentage / 100.toDouble
-  override val basicRateBand                      = 37500
-  override val blindPersonsAllowance              = 2390
-  override val maxLettingsRelief                  = 40000.0
-}
+def TaxRatesAndBands20212022: TaxRatesAndBands =
+  TaxRatesAndBands(
+    taxYear = 2022,
+    maxAnnualExemptAmount = 12300,
+    notVulnerableMaxAnnualExemptAmount = 6150,
+    basicRatePercentage = 18,
+    higherRatePercentage = 28,
+    shareBasicRatePercentage = 10,
+    shareHigherRatePercentage = 20,
+    maxPersonalAllowance = 12570,
+    basicRateBand = 37700,
+    blindPersonsAllowance = 2520,
+    maxLettingsRelief = 40000.0
+  )
 
-object TaxRatesAndBands20192020 extends TaxRatesAndBands {
-  override val taxYear                            = 2020
-  override val maxAnnualExemptAmount              = 12000
-  override val notVulnerableMaxAnnualExemptAmount = 6000
-  override val basicRatePercentage                = 18
-  override val higherRatePercentage               = 28
-  override val shareBasicRatePercentage           = 10
-  override val shareHigherRatePercentage          = 20
-  override val maxPersonalAllowance               = 12500
-  override val basicRate                          = basicRatePercentage / 100.toDouble
-  override val higherRate                         = higherRatePercentage / 100.toDouble
-  override val shareBasicRate                     = shareBasicRatePercentage / 100.toDouble
-  override val shareHigherRate                    = shareHigherRatePercentage / 100.toDouble
-  override val basicRateBand                      = 37500
-  override val blindPersonsAllowance              = 2390
-  override val maxLettingsRelief                  = 40000.0
-}
+def TaxRatesAndBands20202021: TaxRatesAndBands =
+  TaxRatesAndBands(
+    taxYear = 2021,
+    maxAnnualExemptAmount = 12300,
+    notVulnerableMaxAnnualExemptAmount = 6000,
+    basicRatePercentage = 18,
+    higherRatePercentage = 28,
+    shareBasicRatePercentage = 10,
+    shareHigherRatePercentage = 20,
+    maxPersonalAllowance = 12500,
+    basicRateBand = 37500,
+    blindPersonsAllowance = 2390,
+    maxLettingsRelief = 40000.0
+  )
 
-object TaxRatesAndBands20182019 extends TaxRatesAndBands {
-  override val taxYear                            = 2019
-  override val maxAnnualExemptAmount              = 11700
-  override val notVulnerableMaxAnnualExemptAmount = 5850
-  override val basicRatePercentage                = 18
-  override val higherRatePercentage               = 28
-  override val shareBasicRatePercentage           = 10
-  override val shareHigherRatePercentage          = 20
-  override val maxPersonalAllowance               = 11850
-  override val basicRate                          = basicRatePercentage / 100.toDouble
-  override val higherRate                         = higherRatePercentage / 100.toDouble
-  override val shareBasicRate                     = shareBasicRatePercentage / 100.toDouble
-  override val shareHigherRate                    = shareHigherRatePercentage / 100.toDouble
-  override val basicRateBand                      = 34500
-  override val blindPersonsAllowance              = 2390
-  override val maxLettingsRelief                  = 40000.0
-}
+def TaxRatesAndBands20192020: TaxRatesAndBands =
+  TaxRatesAndBands(
+    taxYear = 2020,
+    maxAnnualExemptAmount = 12000,
+    notVulnerableMaxAnnualExemptAmount = 6000,
+    basicRatePercentage = 18,
+    higherRatePercentage = 28,
+    shareBasicRatePercentage = 10,
+    shareHigherRatePercentage = 20,
+    maxPersonalAllowance = 12500,
+    basicRateBand = 37500,
+    blindPersonsAllowance = 2390,
+    maxLettingsRelief = 40000.0
+  )
 
-object TaxRatesAndBands20172018 extends TaxRatesAndBands {
-  override val taxYear                            = 2018
-  override val maxAnnualExemptAmount              = 11300
-  override val notVulnerableMaxAnnualExemptAmount = 5650
-  override val basicRatePercentage                = 18
-  override val higherRatePercentage               = 28
-  override val shareBasicRatePercentage           = 10
-  override val shareHigherRatePercentage          = 20
-  override val maxPersonalAllowance               = 11500
-  override val basicRate                          = basicRatePercentage / 100.toDouble
-  override val higherRate                         = higherRatePercentage / 100.toDouble
-  override val shareBasicRate                     = shareBasicRatePercentage / 100.toDouble
-  override val shareHigherRate                    = shareHigherRatePercentage / 100.toDouble
-  override val basicRateBand                      = 33500
-  override val blindPersonsAllowance              = 2320
-  override val maxLettingsRelief                  = 40000.0
-}
+def TaxRatesAndBands20182019: TaxRatesAndBands =
+  TaxRatesAndBands(
+    taxYear = 2019,
+    maxAnnualExemptAmount = 11700,
+    notVulnerableMaxAnnualExemptAmount = 5850,
+    basicRatePercentage = 18,
+    higherRatePercentage = 28,
+    shareBasicRatePercentage = 10,
+    shareHigherRatePercentage = 20,
+    maxPersonalAllowance = 11850,
+    basicRateBand = 34500,
+    blindPersonsAllowance = 2390,
+    maxLettingsRelief = 40000.0
+  )
 
-object TaxRatesAndBands20162017 extends TaxRatesAndBands {
-  override val taxYear                            = 2017
-  override val maxAnnualExemptAmount              = 11100
-  override val notVulnerableMaxAnnualExemptAmount = 5550
-  override val basicRatePercentage                = 18
-  override val higherRatePercentage               = 28
-  override val shareBasicRatePercentage           = 10
-  override val shareHigherRatePercentage          = 20
-  override val maxPersonalAllowance               = 11000
-  override val basicRate                          = basicRatePercentage / 100.toDouble
-  override val higherRate                         = higherRatePercentage / 100.toDouble
-  override val shareBasicRate                     = shareBasicRatePercentage / 100.toDouble
-  override val shareHigherRate                    = shareHigherRatePercentage / 100.toDouble
-  override val basicRateBand                      = 32000
-  override val blindPersonsAllowance              = 2290
-  override val maxLettingsRelief                  = 40000.0
-}
+def TaxRatesAndBands20172018: TaxRatesAndBands =
+  TaxRatesAndBands(
+    taxYear = 2018,
+    maxAnnualExemptAmount = 11300,
+    notVulnerableMaxAnnualExemptAmount = 5650,
+    basicRatePercentage = 18,
+    higherRatePercentage = 28,
+    shareBasicRatePercentage = 10,
+    shareHigherRatePercentage = 20,
+    maxPersonalAllowance = 11500,
+    basicRateBand = 33500,
+    blindPersonsAllowance = 2320,
+    maxLettingsRelief = 40000.0
+  )
 
-object TaxRatesAndBands20152016 extends TaxRatesAndBands {
-  override val taxYear                            = 2016
-  override val maxAnnualExemptAmount              = 11100
-  override val notVulnerableMaxAnnualExemptAmount = 5550
-  override val basicRatePercentage                = 18
-  override val higherRatePercentage               = 28
-  override val shareBasicRatePercentage           = 18
-  override val shareHigherRatePercentage          = 28
-  override val maxPersonalAllowance               = 10600
-  override val basicRate                          = basicRatePercentage / 100.toDouble
-  override val higherRate                         = higherRatePercentage / 100.toDouble
-  override val shareBasicRate                     = shareBasicRatePercentage / 100.toDouble
-  override val shareHigherRate                    = shareHigherRatePercentage / 100.toDouble
-  override val basicRateBand                      = 31785
-  override val blindPersonsAllowance              = 2290
-  override val maxLettingsRelief                  = 40000.0
-}
+def TaxRatesAndBands20162017: TaxRatesAndBands =
+  TaxRatesAndBands(
+    taxYear = 2017,
+    maxAnnualExemptAmount = 11100,
+    notVulnerableMaxAnnualExemptAmount = 5550,
+    basicRatePercentage = 18,
+    higherRatePercentage = 28,
+    shareBasicRatePercentage = 10,
+    shareHigherRatePercentage = 20,
+    maxPersonalAllowance = 11000,
+    basicRateBand = 32000,
+    blindPersonsAllowance = 2290,
+    maxLettingsRelief = 40000.0
+  )
+
+def TaxRatesAndBands20152016: TaxRatesAndBands =
+  TaxRatesAndBands(
+    taxYear = 2016,
+    maxAnnualExemptAmount = 11100,
+    notVulnerableMaxAnnualExemptAmount = 5550,
+    basicRatePercentage = 18,
+    higherRatePercentage = 28,
+    shareBasicRatePercentage = 18,
+    shareHigherRatePercentage = 28,
+    maxPersonalAllowance = 10600,
+    basicRateBand = 31785,
+    blindPersonsAllowance = 2290,
+    maxLettingsRelief = 40000.0
+  )

--- a/app/controllers/TaxRatesAndBandsController.scala
+++ b/app/controllers/TaxRatesAndBandsController.scala
@@ -71,14 +71,10 @@ class TaxRatesAndBandsController @Inject() (val cc: ControllerComponents)(implic
       case Right(parsedDate) =>
         val taxYear            = Date.getTaxYear(parsedDate)
         val currentTaxYear     = Date.getTaxYear(LocalDate.now())
-        val calculationTaxYear = if (taxYear > currentTaxYear) {
-          currentTaxYear // Future year -> use current year
-        } else {
-          TaxRatesAndBands.getClosestTaxYear(taxYear) // Past/present -> use closest available rates
-        }
+        val calculationTaxYear = if (taxYear > currentTaxYear) currentTaxYear else taxYear
         val result             = TaxYearModel(
           Date.taxYearToString(taxYear),
-          TaxRatesAndBands.filterRatesByTaxYear(taxYear).nonEmpty,
+          TaxRatesAndBandsValidation.checkValidTaxYear(taxYear),
           Date.taxYearToString(calculationTaxYear)
         )
         Future.successful(Ok(Json.toJson(result)))

--- a/app/controllers/nonresident/CalculatorController.scala
+++ b/app/controllers/nonresident/CalculatorController.scala
@@ -18,7 +18,6 @@ package controllers.nonresident
 
 import common.Date
 import common.Date._
-import config.TaxRatesAndBands
 import models.nonResident._
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import play.api.mvc._
@@ -199,7 +198,6 @@ class CalculatorController @Inject() (
     )
 
     val taxYear          = getTaxYear(disposalDate)
-    val calcTaxYear      = TaxRatesAndBands.getClosestTaxYear(taxYear)
     val prrValue: Double = prrClaimed.getOrElse(0)
 
     val flatModel =
@@ -214,7 +212,7 @@ class CalculatorController @Inject() (
         annualExemptAmount = annualExemptAmount,
         broughtForwardLoss = broughtForwardLoss,
         prrClaimed = prrClaimed,
-        calcTaxYear = calcTaxYear
+        calcTaxYear = taxYear
       )
 
     val rebasedModel =
@@ -230,7 +228,7 @@ class CalculatorController @Inject() (
           annualExemptAmount = annualExemptAmount,
           broughtForwardLoss = broughtForwardLoss,
           prrClaimed = prrClaimed,
-          calcTaxYear = calcTaxYear,
+          calcTaxYear = taxYear,
           useClaimedPrrForReliefsRemaining = true
         )
       }
@@ -248,7 +246,7 @@ class CalculatorController @Inject() (
           annualExemptAmount = annualExemptAmount,
           broughtForwardLoss = broughtForwardLoss,
           prrClaimed = prrClaimed,
-          calcTaxYear = calcTaxYear,
+          calcTaxYear = taxYear,
           useClaimedPrrForReliefsRemaining = true
         )
       }

--- a/app/controllers/resident/properties/CalculatorController.scala
+++ b/app/controllers/resident/properties/CalculatorController.scala
@@ -19,7 +19,6 @@ package controllers.resident.properties
 import common.Date
 import common.Date._
 import common.Math._
-import config.TaxRatesAndBands
 import models.CalculationResultModel
 import models.resident.properties.{PropertyCalculateTaxOwedModel, PropertyChargeableGainModel, PropertyTotalGainModel}
 import models.resident.{ChargeableGainResultModel, TaxOwedResultModel}
@@ -53,8 +52,7 @@ class CalculatorController @Inject() (
   def calculateChargeableGain(propertyChargeableGainModel: PropertyChargeableGainModel): Action[AnyContent] =
     Action.async {
 
-      val taxYear     = getTaxYear(propertyChargeableGainModel.disposalDate)
-      val calcTaxYear = TaxRatesAndBands.getClosestTaxYear(taxYear)
+      val taxYear = getTaxYear(propertyChargeableGainModel.disposalDate)
 
       val gain = calculationService.calculateGainFlat(
         propertyChargeableGainModel.propertyTotalGainModel.totalGainModel.disposalValue,
@@ -69,7 +67,7 @@ class CalculatorController @Inject() (
         gain,
         prrUsed,
         propertyChargeableGainModel.lettingReliefs,
-        calcTaxYear
+        taxYear
       )
       val chargeableGain                = calculationService.calculateChargeableGain(
         gain,
@@ -132,8 +130,7 @@ class CalculatorController @Inject() (
   def calculateTaxOwed(propertyCalculateTaxOwedModel: PropertyCalculateTaxOwedModel): Action[AnyContent] =
     Action.async {
 
-      val taxYear     = getTaxYear(propertyCalculateTaxOwedModel.propertyChargeableGainModel.disposalDate)
-      val calcTaxYear = TaxRatesAndBands.getClosestTaxYear(taxYear)
+      val taxYear = getTaxYear(propertyCalculateTaxOwedModel.propertyChargeableGainModel.disposalDate)
 
       val gain                                      = calculationService.calculateGainFlat(
         propertyCalculateTaxOwedModel.propertyChargeableGainModel.propertyTotalGainModel.totalGainModel.disposalValue,
@@ -150,7 +147,7 @@ class CalculatorController @Inject() (
         gain,
         prrUsed,
         propertyCalculateTaxOwedModel.propertyChargeableGainModel.lettingReliefs,
-        calcTaxYear
+        taxYear
       )
       val chargeableGain                            = calculationService.calculateChargeableGain(
         gain,
@@ -182,7 +179,7 @@ class CalculatorController @Inject() (
         None,
         aeaUsed,
         0.0,
-        calcTaxYear,
+        taxYear,
         isProperty = true
       )
       val result: TaxOwedResultModel                = TaxOwedResultModel(

--- a/app/controllers/resident/shares/CalculatorController.scala
+++ b/app/controllers/resident/shares/CalculatorController.scala
@@ -19,7 +19,6 @@ package controllers.resident.shares
 import common.Date
 import common.Date._
 import common.Math._
-import config.TaxRatesAndBands
 import models.CalculationResultModel
 import models.resident.shares.{CalculateTaxOwedModel, ChargeableGainModel, TotalGainModel}
 import models.resident.{ChargeableGainResultModel, TaxOwedResultModel}
@@ -118,7 +117,6 @@ class CalculatorController @Inject() (
     val chargeableGainModel = calculateTaxOwedModel.chargeableGainModel
 
     val taxYear                                   = getTaxYear(calculateTaxOwedModel.disposalDate)
-    val calcTaxYear                               = TaxRatesAndBands.getClosestTaxYear(taxYear)
     val gain                                      = calculationService.calculateGainFlat(
       chargeableGainModel.totalGainModel.disposalValue,
       chargeableGainModel.totalGainModel.disposalCosts,
@@ -157,7 +155,7 @@ class CalculatorController @Inject() (
       None,
       aeaUsed,
       0.0,
-      calcTaxYear,
+      taxYear,
       isProperty = false,
       Some(calculateTaxOwedModel.disposalDate),
       isMidYearChangeApplicable = true

--- a/app/services/CalculationService.scala
+++ b/app/services/CalculationService.scala
@@ -106,8 +106,7 @@ class CalculationService @Inject() {
   ): Double = {
 
     val taxYear             = getTaxYear(disposalDate)
-    val calcTaxYear         = TaxRatesAndBands.getClosestTaxYear(taxYear)
-    val taxRatesAndBands    = TaxRatesAndBands.getRates(calcTaxYear)
+    val taxRatesAndBands    = TaxRatesAndBands.getRates(taxYear)
     val flatGain            =
       calculateGainFlat(disposalValue, disposalCosts, acquisitionValueAmt, acquisitionCostsAmt, improvementsAmt)
     val fractionOfOwnership =

--- a/test/config/TaxRatesAndBandsSpec.scala
+++ b/test/config/TaxRatesAndBandsSpec.scala
@@ -89,6 +89,53 @@ class TaxRatesAndBandsSpec extends PlaySpec with ScalaCheckPropertyChecks with C
     val acceptedMinTaxYear = TaxRatesAndBands.liveTaxRates.head.taxYear
     val acceptedMaxTaxYear = TaxRatesAndBands.liveTaxRates.last.taxYear
 
+    "the requested tax year is configured" must {
+      "return the matching tax year config" in {
+        val rates = TaxRatesAndBands.getRates(2024)
+
+        rates.taxYear shouldEqual 2024
+        rates.maxAnnualExemptAmount shouldEqual TaxRatesAndBands20232024.maxAnnualExemptAmount
+      }
+    }
+
+    "the requested tax year is not configured" must {
+      "use the latest live config for an earlier tax year" in {
+        val requestedTaxYear = acceptedMinTaxYear - 1
+        val latestRates      = TaxRatesAndBands.liveTaxRates.last
+        val rates            = TaxRatesAndBands.getRates(requestedTaxYear)
+
+        rates.taxYear shouldEqual requestedTaxYear
+        rates.maxAnnualExemptAmount shouldEqual latestRates.maxAnnualExemptAmount
+        rates.maxPersonalAllowance shouldEqual latestRates.maxPersonalAllowance
+        rates.effectiveDate shouldEqual None
+      }
+
+      "use the latest config before the requested tax year" in {
+        val rates = TaxRatesAndBands.getRates(
+          year = 2024,
+          rates = List(TaxRatesAndBands20222023, TaxRatesAndBands20242025),
+          disposalDate = None,
+          isMidYearChangeApplicable = false
+        )
+
+        rates.taxYear shouldEqual 2024
+        rates.maxAnnualExemptAmount shouldEqual TaxRatesAndBands20222023.maxAnnualExemptAmount
+        rates.maxPersonalAllowance shouldEqual TaxRatesAndBands20222023.maxPersonalAllowance
+        rates.effectiveDate shouldEqual None
+      }
+
+      "use the latest live config for a future tax year" in {
+        val requestedTaxYear = acceptedMaxTaxYear + 1
+        val latestRates      = TaxRatesAndBands.liveTaxRates.last
+        val rates            = TaxRatesAndBands.getRates(requestedTaxYear)
+
+        rates.taxYear shouldEqual requestedTaxYear
+        rates.maxAnnualExemptAmount shouldEqual latestRates.maxAnnualExemptAmount
+        rates.maxPersonalAllowance shouldEqual latestRates.maxPersonalAllowance
+        rates.effectiveDate shouldEqual None
+      }
+    }
+
     "checked for closest tax year" must {
       "return correct closest tax year" in {
         check {

--- a/test/controllers/TaxRatesAndBandsControllerSpec.scala
+++ b/test/controllers/TaxRatesAndBandsControllerSpec.scala
@@ -16,6 +16,7 @@
 
 package controllers
 
+import common.Date
 import org.apache.pekko.actor.ActorSystem
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
@@ -255,12 +256,14 @@ class TaxRatesAndBandsControllerSpec extends PlaySpec with GuiceOneAppPerSuite w
 
   "validating the getTaxYear method" when {
     "calling with current date (today)" must {
-      val today = LocalDate.now()
-      val dateFormatter = DateTimeFormatter.ofPattern("y-M-d")
-      val formattedDate = today.format(dateFormatter)
-      val result = controller.getTaxYear(formattedDate)(fakeRequest)
-      val data = contentAsString(result)
-      val json = Json.parse(data)
+      val today                = LocalDate.now()
+      val dateFormatter        = DateTimeFormatter.ofPattern("y-M-d")
+      val formattedDate        = today.format(dateFormatter)
+      val result               = controller.getTaxYear(formattedDate)(fakeRequest)
+      val data                 = contentAsString(result)
+      val json                 = Json.parse(data)
+      val currentTaxYear       = Date.getTaxYear(today)
+      val currentTaxYearString = Date.taxYearToString(currentTaxYear)
 
       "return a status 200" in {
         status(result) mustBe 200
@@ -271,21 +274,18 @@ class TaxRatesAndBandsControllerSpec extends PlaySpec with GuiceOneAppPerSuite w
       }
 
       "return the current tax year as supplied" in {
-        val currentTaxYearInt = if (today.isAfter(LocalDate.parse(s"${today.getYear}-04-05"))) {
-          today.getYear + 1
-        } else {
-          today.getYear
-        }
-        val currentTaxYearString = s"${currentTaxYearInt - 1}/${currentTaxYearInt.toString.takeRight(2)}"
         (json \ "taxYearSupplied").as[String] mustBe currentTaxYearString
       }
 
-      "return a supplied TaxYearModel with calculationTaxYear matching the closest available config" in {
-        val calculationTaxYear = (json \ "calculationTaxYear").as[String]
-        calculationTaxYear must not be empty
+      "return isValidYear as true" in {
+        (json \ "isValidYear").as[Boolean] mustBe true
+      }
+
+      "return calculationTaxYear as the year to use for rates" in {
+        (json \ "calculationTaxYear").as[String] mustBe currentTaxYearString
       }
     }
-    "calling with the date 10/10/2016" must {
+    "calling with the date 10/10/2016"  must {
       val result = controller.getTaxYear("2016-10-10")(fakeRequest)
       val data   = contentAsString(result)
       val json   = Json.parse(data)
@@ -298,15 +298,15 @@ class TaxRatesAndBandsControllerSpec extends PlaySpec with GuiceOneAppPerSuite w
         contentType(result) mustBe Some("application/json")
       }
 
-      "return a supplied TaxYearModel for 2016/17" in {
+      "return taxYearSupplied as 2016/17" in {
         (json \ "taxYearSupplied").as[String] mustBe "2016/17"
       }
 
-      "return a supplied TaxYearModel with isValidYear as true" in {
+      "return isValidYear as true" in {
         (json \ "isValidYear").as[Boolean] mustBe true
       }
 
-      "return a supplied TaxYearModel with calculationTaxYear as 2016/17" in {
+      "return calculationTaxYear as 2016/17" in {
         (json \ "calculationTaxYear").as[String] mustBe "2016/17"
       }
 
@@ -325,23 +325,25 @@ class TaxRatesAndBandsControllerSpec extends PlaySpec with GuiceOneAppPerSuite w
         contentType(result) mustBe Some("application/json")
       }
 
-      "return a supplied TaxYearModel for 2014/15" in {
+      "return taxYearSupplied as 2014/15" in {
         (json \ "taxYearSupplied").as[String] mustBe "2014/15"
       }
 
-      "return a supplied TaxYearModel with isValidYear as false" in {
+      "return isValidYear as false" in {
         (json \ "isValidYear").as[Boolean] mustBe false
       }
 
-      "return a supplied TaxYearModel with calculationTaxYear as 2015/16" in {
-        (json \ "calculationTaxYear").as[String] mustBe "2015/16"
+      "return calculationTaxYear as the year to use for rates" in {
+        (json \ "calculationTaxYear").as[String] mustBe "2014/15"
       }
     }
 
-    "calling with the date 10/10/2099" must {
-      val result = controller.getTaxYear("2099-10-10")(fakeRequest)
-      val data   = contentAsString(result)
-      val json   = Json.parse(data)
+    "calling with a future date" must {
+      val currentTaxYear       = Date.getTaxYear(LocalDate.now())
+      val currentTaxYearString = Date.taxYearToString(currentTaxYear)
+      val futureTaxYear        = Date.taxYearToString(currentTaxYear + 2)
+      val result               = controller.getTaxYear(s"${currentTaxYear + 1}-10-10")(fakeRequest)
+      val json                 = Json.parse(contentAsString(result))
 
       "return a status 200" in {
         status(result) mustBe 200
@@ -351,16 +353,16 @@ class TaxRatesAndBandsControllerSpec extends PlaySpec with GuiceOneAppPerSuite w
         contentType(result) mustBe Some("application/json")
       }
 
-      "return a supplied TaxYearModel for 2099/00" in {
-        (json \ "taxYearSupplied").as[String] mustBe "2099/00"
+      "return taxYearSupplied as the future tax year" in {
+        (json \ "taxYearSupplied").as[String] mustBe futureTaxYear
       }
 
-      "return a supplied TaxYearModel with isValidYear as true" in {
+      "return isValidYear as false" in {
         (json \ "isValidYear").as[Boolean] mustBe false
       }
 
-      "return a supplied TaxYearModel with calculationTaxYear as 2026/27" in {
-        (json \ "calculationTaxYear").as[String] mustBe "2026/27"
+      "return calculationTaxYear as the current tax year" in {
+        (json \ "calculationTaxYear").as[String] mustBe currentTaxYearString
       }
 
     }


### PR DESCRIPTION
Updated tax-rate lookup so requests for tax years without an explicit config use latest live tax configuration, with rate tax year adjusted to the requested tax year.

Also, aligned tax rate configuration models with service.

  <details>
  <summary>AT results for all 3 calculator frontends</summary>

**Non-Res**
```
[info]   When The non-resident Summary continue button is clicked
[info]   Then The non-resident What Next page is displayed correctly
[info] Run completed in 3 minutes, 23 seconds.
[info] Total number of tests run: 24
[info] Suites: completed 13, aborted 0
[info] Tests: succeeded 24, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 239 s (0:03:59.0), completed 10 Jul 2026, 10:30:56
```

**Res Prop**
```
[info]   When the resident properties Self Assessment option YES is selected
[info]   And the Continue button is clicked
[info]   Then the What happens next page is displayed correctly
[info]   When they click on the feedback link
[info]   Then they are redirected to the feedback page
[info] Run completed in 4 minutes, 8 seconds.
[info] Total number of tests run: 24
[info] Suites: completed 9, aborted 0
[info] Tests: succeeded 24, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 251 s (0:04:11.0), completed 10 Jul 2026, 10:42:26
```

**Res Shares**
```
[info]   Then the resident shares Summary page has a Total Profit of £58,100
[info]   And the resident shares Summary page has a Taxable Profit of £44,000
[info]   And the resident shares Summary page has a Tax owed of £8,500.00
[info] Run completed in 1 minute, 39 seconds.
[info] Total number of tests run: 21
[info] Suites: completed 11, aborted 0
[info] Tests: succeeded 21, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 102 s (0:01:42.0), completed 10 Jul 2026, 10:45:44
```

</details>